### PR TITLE
Add Waterfall support for AIM-120 missile

### DIFF
--- a/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
+++ b/BDArmory/Distribution/GameData/BDArmory/ChangeLog.txt
@@ -2180,8 +2180,9 @@ FIXES
 - Fix various NREs.
 IMPROVEMENTS
 - General:
-	- Add Waterfall config for the Saturn engine.
-	- Increase the HP of the combat seat to the same as a kerbal (500).
+        - Add Waterfall config for the Saturn engine.
+        - Add Waterfall config for the AIM-120 missile.
+        - Increase the HP of the combat seat to the same as a kerbal (500).
 	- Add a time scaling option to the GamePlay section of the settings for speeding up/slowing down the game rate while competitions are active.
 		- This does not affect the physics time-step, which remains at 0.02, but simply tries to make the in-game clock go faster with respect to a wall clock, so it should not affect the physics (if they're implemented correctly).
 		- WARNING: This is likely to mess with any other mod that adjusts the time rate, e.g., TimeControl, if they're active at the same time.

--- a/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/Aim120Waterfall.cfg
+++ b/BDArmory/Distribution/GameData/BDArmory/Parts/aim-120/Aim120Waterfall.cfg
@@ -1,0 +1,26 @@
+@PART[bahaAim120]:NEEDS[Waterfall]:FOR[StockWaterfallEffects]
+{
+    MODULE
+    {
+        name = ModuleWaterfallFX
+        moduleID = aim120Engine
+        CONTROLLER
+        {
+            name = throttle
+            linkedTo = throttle
+        }
+        CONTROLLER
+        {
+            name = atmosphereDepth
+            linkedTo = atmosphere_density
+        }
+        TEMPLATE
+        {
+            templateName = stock-aerozine50-lower-1
+            overrideParentTransform = boostTransform
+            position = 0,0,0
+            rotation = 0,0,0
+            scale = 1,1,1
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Waterfall plume config for AIM-120 missile
- log this in the changelog

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3881d9c832499f71dd923467783